### PR TITLE
fix: add depends on to igw on public subnets

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -87,6 +87,8 @@ resource "aws_subnet" "public" {
     var.tags,
     local.public_subnet_tags
   )
+
+  depends_on = [aws_internet_gateway.igw]
 }
 
 # public route tables, one per subnet


### PR DESCRIPTION
without this, during a destroy, terraform tries and fails to destroy the
igw very early on. this fixes that minor efficiency problem