### PR TITLE
fix: loki and cortex s3 policy

### DIFF
--- a/cortex.tf
+++ b/cortex.tf
@@ -34,11 +34,10 @@ data "aws_iam_policy_document" "cortex" {
 
   statement {
     actions = [
+      "s3:ListBucket",
+      "s3:PutObject",
       "s3:GetObject",
       "s3:DeleteObject",
-      "s3:PutObject",
-      "s3:AbortMultipartUpload",
-      "s3:ListMultipartUploadParts",
     ]
     resources = [
       "arn:aws:s3:::${local.cortex_bucket_name}",

--- a/loki.tf
+++ b/loki.tf
@@ -34,11 +34,10 @@ data "aws_iam_policy_document" "loki" {
 
   statement {
     actions = [
+      "s3:ListBucket",
+      "s3:PutObject",
       "s3:GetObject",
       "s3:DeleteObject",
-      "s3:PutObject",
-      "s3:AbortMultipartUpload",
-      "s3:ListMultipartUploadParts",
     ]
     resources = [
       "arn:aws:s3:::${local.loki_bucket_name}",


### PR DESCRIPTION
I think the policies got copied from velero for some reason, which
results in cortex being unable to do it's initial sync with it's
backend.