### PR TITLE
feat!: upgrade aws provider to v5, upgrade lambda node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ module "platform" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.0 |
 
@@ -130,6 +130,7 @@ module "platform" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | Name of EKS cluster. Used in naming of many EKS resources, including cluster, IAM roles and policies, S3 buckets for Velero, Cortex, Loki, etc. | `string` | n/a | yes |
 | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | Name of the VPC to create. Used in VPC resource tags for naming. | `string` | n/a | yes |
+| <a name="input_alarm_lambda_settings"></a> [alarm\_lambda\_settings](#input\_alarm\_lambda\_settings) | Alarm lambda function settings. Default settings are provided for slack and teams, but can be overridden here. | <pre>map(object({<br>    source_code_path    = string<br>    zip_source_filename = string<br>    handler             = string<br>    runtime             = string<br>  }))</pre> | `{}` | no |
 | <a name="input_alarm_sns_topics"></a> [alarm\_sns\_topics](#input\_alarm\_sns\_topics) | List of SNS topics to create for alerting on CloudWatch Synthetics Canaries. All created SNS topics will be supplied to the Synthetics Canary alarms. publish\_target\_type should specify one of the supported targets, currently slack and teams. | <pre>list(object({<br>    name                = string<br>    publish_target_type = string<br>    webhook_url         = string<br>  }))</pre> | `[]` | no |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of Availability zones with corresponding public and private subnet CIDRs to create subnets in each. Default EKS node groups get created for each availability zone specified. | <pre>list(object({<br>    az_name             = string<br>    private_subnet_cidr = string<br>    public_subnet_cidr  = string<br>  }))</pre> | `[]` | no |
 | <a name="input_aws_auth_roles"></a> [aws\_auth\_roles](#input\_aws\_auth\_roles) | Extra roles to add to the mapRoles field in the aws\_auth configmap, for granting access via IAM roles | <pre>list(object({<br>    rolearn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |

--- a/modules/eks-irsa-role/README.md
+++ b/modules/eks-irsa-role/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Inputs
 

--- a/modules/eks-irsa-role/versions.tf
+++ b/modules/eks-irsa-role/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/sns.tf
+++ b/sns.tf
@@ -71,20 +71,25 @@ resource "aws_iam_role_policy_attachment" "alarm_lambda_access" {
 # create the lambda function
 locals {
   # default settings for different supported publish types
-  alarm_lambda_settings = {
+  alarm_lambda_settings_defaults = {
     slack = {
       source_code_path    = "${path.module}/assets/default-slack-notifier-lambda-function/index.js"
       zip_source_filename = "index.js"
       handler             = "index.handler"
-      runtime             = "nodejs16.x"
+      runtime             = "nodejs20.x"
     }
     teams = {
       source_code_path    = "${path.module}/assets/default-teams-notifier-lambda-function/index.js"
       zip_source_filename = "index.js"
       handler             = "index.handler"
-      runtime             = "nodejs16.x"
+      runtime             = "nodejs20.x"
     }
   }
+
+  alarm_lambda_settings = merge(
+    local.alarm_lambda_settings_defaults,
+    var.alarm_lambda_settings,
+  )
 }
 
 # create the zip file for the alarm lambda function

--- a/variables.tf
+++ b/variables.tf
@@ -249,6 +249,17 @@ variable "alarm_sns_topics" {
   }
 }
 
+variable "alarm_lambda_settings" {
+  description = "Alarm lambda function settings. Default settings are provided for slack and teams, but can be overridden here."
+  type = map(object({
+    source_code_path    = string
+    zip_source_filename = string
+    handler             = string
+    runtime             = string
+  }))
+  default = {}
+}
+
 variable "create_cloudwatch_synthetics_bucket" {
   description = "Whether to create an S3 bucket for CloudWatch Synthetics."
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/vpc.tf
+++ b/vpc.tf
@@ -123,7 +123,6 @@ resource "aws_route_table_association" "public" {
 resource "aws_eip" "ngw" {
   count = length(var.availability_zones)
 
-  vpc = true
   tags = merge(
     { "Name" = "${var.vpc_name}-ngw-${var.availability_zones[count.index].az_name}" },
     var.tags,


### PR DESCRIPTION
this change came about because the lambda node version 16 is being removed by aws this year.

version 4 of the aws provider doesn't contain any lambda runtime version of node above 16, so we have to upgrade the provider.

mark this change as breaking, as it will require users of the provider to upgrade the aws provider configuration.

additionally, adds a configuration for overriding alert lambda settings.

and removes a hardcoded vpc configuration because it is deprecated and causes a warning message.