### PR TITLE
fix: define velero s3 bucket ownership controls

### DIFF
--- a/velero.tf
+++ b/velero.tf
@@ -12,6 +12,14 @@ resource "aws_s3_bucket" "velero" {
   tags   = var.tags
 }
 
+resource "aws_s3_bucket_ownership_controls" "velero" {
+  count  = local.create_velero_bucket ? 1 : 0
+  bucket = aws_s3_bucket.velero[count.index].id
+  rule {
+      object_ownership = "ObjectWriter"
+  }
+}
+
 resource "aws_s3_bucket_acl" "velero" {
   count  = local.create_velero_bucket ? 1 : 0
   bucket = aws_s3_bucket.velero[count.index].id


### PR DESCRIPTION
Hi! 👋 

Thanks for making these modules open source!

While trying this out I ran into an issue during provisioning due to an API change on AWS' side: `Error: error creating S3 bucket ACL for <bucket-name>: AccessControlListNotSupported: The bucket does not allow ACLs), you need to run terraform apply`

Defining the object ownership as `ObjectWriter` appears to be the solution to retain the ACL as defined. I think it would also be possible to use a different setting and skip the ACL, but I'm not exactly sure how this ACL is used.