### PR TITLE
fix!: node group to use only one availability zone

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -86,7 +86,7 @@ resource "aws_eks_node_group" "default" {
   cluster_name           = aws_eks_cluster.cluster.name
   instance_types         = var.eks_default_node_groups_instance_types
   node_role_arn          = aws_iam_role.default_node_group_role.arn
-  subnet_ids             = aws_subnet.private[*].id
+  subnet_ids             = aws_subnet.private[count.index].id
   version                = local.default_node_group_version
   tags                   = var.tags
 


### PR DESCRIPTION
Currently, the node groups are being created with access to all available subnets, defeating the whole purpose of having different node groups. Each node group can have its nodes created in any subnet, and thus any az. I think this negatively impacts the cluster autoscaler's ability to scale correctly.

I think this was an oversight on my part when I created this part of the module, and I never realized until now, so I'm correcting it :sweat_smile:

I'm considering this to be a breaking change as it will cause node groups to get recreated, which is unexpected behavior.

BREAKING CHANGE: will recreate node groups.